### PR TITLE
Fix(fastfetch-git): deleted libmagickcore-dev dependency (called twice)

### DIFF
--- a/packages/fastfetch-git/fastfetch-git.pacscript
+++ b/packages/fastfetch-git/fastfetch-git.pacscript
@@ -11,7 +11,7 @@ pkgname="fastfetch"
 pkgdesc="Like neofetch, but much faster because written in c"
 url="https://github.com/LinusDierheimer/fastfetch.git"
 pkgver="2.6.3"
-makedepends=("cmake" "libpci-dev" "libvulkan-dev" "libwayland-dev" "libxrandr-dev" "libxcb-randr0-dev" "libdconf-dev" "libmagick++-dev" "libmagickcore-dev" "libdbus-1-dev" "libmagickcore-dev" "libpci-dev" "libxfconf-0-dev" "libegl-dev" "libglx-dev" "libosmesa6-dev" "ocl-icd-opencl-dev" "libnm-dev" "libpulse-dev" "libddcutil-dev" "directx-headers-dev")
+makedepends=("cmake" "libpci-dev" "libvulkan-dev" "libwayland-dev" "libxrandr-dev" "libxcb-randr0-dev" "libdconf-dev" "libmagick++-dev" "libmagickcore-dev" "libdbus-1-dev" "libpci-dev" "libxfconf-0-dev" "libegl-dev" "libglx-dev" "libosmesa6-dev" "ocl-icd-opencl-dev" "libnm-dev" "libpulse-dev" "libddcutil-dev" "directx-headers-dev")
 optdepends=("libvulkan1: Vulkan module and GPU fallback"
   "libegl1: OpenGL module"
   "libxcb-randr0: Resolution and refresh rate support for X11 sessions"


### PR DESCRIPTION
not critical :
libmagickcore-dev was called twice in makedepends